### PR TITLE
Speed up the build of unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,16 @@ if (BUILD_UNITTEST)
     set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # for tooling support
     set(EXTERNAL_LIB_HEADERS lib/json/single_include)
 
-    set(SOURCE_FILES
+    # Use C++11
+    set(CMAKE_CXX_STANDARD 11)
+
+    # Set default compile flags for GCC
+    if (CMAKE_COMPILER_IS_GNUCXX)
+        add_compile_options(-g -v -Wall -Wextra -Wunused)
+    endif (CMAKE_COMPILER_IS_GNUCXX)
+
+    message(DEBUG "Create WARDuino as shared library")
+    add_library(warduino_lib SHARED
             src/WARDuino/WARDuino.cpp
             src/WARDuino/CallbackHandler.cpp
             src/Primitives/emulated.cpp
@@ -94,14 +103,8 @@ if (BUILD_UNITTEST)
             src/Edward/proxy_supervisor.cpp
             src/Edward/RFC.cpp)
 
-    # Use C++11
-    set(CMAKE_CXX_STANDARD 11)
-
-    # Set default compile flags for GCC
-    if (CMAKE_COMPILER_IS_GNUCXX)
-        add_compile_options(-g -v -Wall -Wextra -Wunused)
-    endif (CMAKE_COMPILER_IS_GNUCXX)
-
+    target_include_directories(warduino_lib PRIVATE ${EXTERNAL_LIB_HEADERS} "${PROJECT_BINARY_DIR}/include")
+    target_include_directories(warduino_lib PUBLIC src/)
 
     include(FetchContent)
     FetchContent_Declare(
@@ -118,17 +121,21 @@ if (BUILD_UNITTEST)
 
     aux_source_directory(${PATH_TO_UNIT_TEST}/shared/ SHARED_SRC)
 
+
+
     message(DEBUG "Shared source code for unit tests path: " ${SHARED_SRC})
 
     file(GLOB TEST_SRC_FILES ${PATH_TO_UNIT_TEST}/*.cpp)
 
     message(DEBUG "Unit test source codes: " ${TEST_SRC_FILES})
 
+
+
     foreach (TEST_FILE ${TEST_SRC_FILES})
         get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
         message(DEBUG "Add executable for " ${TEST_FILE})
-        add_executable(${TEST_NAME} ${TEST_FILE} ${SOURCE_FILES} ${SHARED_SRC})
-        target_link_libraries(${TEST_NAME} gtest_main)
+        add_executable(${TEST_NAME} ${TEST_FILE} ${SHARED_SRC})
+        target_link_libraries(${TEST_NAME} gtest_main warduino_lib)
         target_include_directories(${TEST_NAME} PRIVATE ${EXTERNAL_LIB_HEADERS} "${PROJECT_BINARY_DIR}/include")
         add_test(${TEST_NAME} ${TEST_NAME})
     endforeach ()


### PR DESCRIPTION
Currently, WARDuino is continuously built for each new unit test executable that needs to be made. This PR speeds up the build process by building WARDuino as a shared library and linked to each unit test.